### PR TITLE
Always update key dependencies of dirty context cache entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /classes
 /.idea
 /cljfx.iml
+*.swp

--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ flavors:
 Returned values from subscription functions are memoized in this context
 (so it actually is a *memoization* context), and subsequent `sub` calls
 will result in cache lookup. The best thing about context is that not
-only it supports updating wrapped values via `swap-context` and
+only does it support updating wrapped values via `swap-context` and
 `reset-context`, it also reuses this memoization cache to minimize
 re-calculation of subscription functions in successors of this context.
 This is done via tracking of `fx/sub` calls inside subscription

--- a/src/cljfx/context.clj
+++ b/src/cljfx/context.clj
@@ -149,7 +149,11 @@ Possible reasons:
     (some #(contains? s2 %) s1)))
 
 (defn- invalidate-cache [cache old-m new-m]
-  (let [changed-keys (into #{} (remove #(= (old-m %) (new-m %))) (keys old-m))
+  (let [changed-keys (into #{}
+                           (comp (mapcat keys)
+                                 (distinct)
+                                 (remove #(= (old-m %) (new-m %))))
+                           [old-m new-m])
         changed-sub-ids (into #{} (map vector) changed-keys)]
     (reduce (fn [acc [k v]]
               (let [direct-deps (::direct-deps v)]

--- a/test/cljfx/context_test.clj
+++ b/test/cljfx/context_test.clj
@@ -20,7 +20,14 @@
                  (context/sub context fib (- n 1)))))]
     (context/sub context f 10)
     (fact
-      @*tracker => 11)))
+      @*tracker => 11))
+  (testing "a missing entry is treated like a nil entry"
+    (let [context (context/create {} identity)
+          f #(context/sub % :entry)
+          _ (fact (context/sub context f) => nil)
+          context (context/swap context assoc :entry 0)
+          _ (fact (context/sub context f) => 0)
+          ])))
 
 (deftest after-changing-context-only-affected-subscriptions-are-recalculated
   (let [*greeting-call-counter (atom 0)
@@ -162,4 +169,3 @@
             "Updating context with independent change does not trigger recalculation"
             (context/sub context-3 inc-db) => 3
             @*inc-db-call-counter => 2)]))
-

--- a/test/cljfx/context_test.clj
+++ b/test/cljfx/context_test.clj
@@ -84,6 +84,45 @@
           (context/sub context-3 template) => "Привет, %s!"
           @*template-call-counter => 2)))))
 
+; case where a dependency changes its key deps, but returns the same result.
+; Dirty dependents should update
+; their key deps, regardless if they need a full recalculation.
+(deftest dirty-cache-entry-always-updates-its-key-deps
+  ;; TODO test that circular dirty deps don't do unnecessary recalculation
+  (let [*template-counter (atom 0)
+        *parent-child-counter (atom 0)
+        parent-child (fn [context]
+                       (swap! *parent-child-counter inc)
+                       (when (context/sub context :parent)
+                         (context/sub context :child)))
+        template (fn [context]
+                   (swap! *template-counter inc)
+                   (context/sub context parent-child))
+
+        context (context/create {} identity)
+        _ (facts
+            "[template] directly depends on [parent-child]. Both have key deps #{:parent}"
+            (context/sub context template) => nil
+            @*template-counter => 1
+            @*parent-child-counter => 1)
+        context (context/swap context assoc :parent :parent)
+        _ (facts
+            "[template] not recalculated because parent-child returns same result"
+            (context/sub context template) => nil
+            @*template-counter => 1)
+        _ (facts
+            "[parent-child] recalculated because it is a dependency of [template]"
+            @*parent-child-counter => 2)
+        context (context/swap context assoc :child :child)
+        _ (facts
+            "[template] has #{:parent :child} key deps and so is recalculated."
+            (context/sub context template) => :child
+            @*template-counter => 2)
+        _ (facts
+            "[parent-child] recalculated exactly once to verify that [template] cache entry should be evicted"
+            @*parent-child-counter => 3)
+        ]))
+
 (deftest creating-derived-contexts-inside-subs-add-dependency-on-context-itself
   (let [*sub-context-call-counter (atom 0)
         context (context/create {:db 1} identity)

--- a/test/cljfx/context_test/context_dirty_entry_updates_key_deps.clj
+++ b/test/cljfx/context_test/context_dirty_entry_updates_key_deps.clj
@@ -1,0 +1,82 @@
+(ns cljfx.context-test.context-dirty-entry-updates-key-deps
+  (:require [cljfx.api :as fx]))
+
+;; Event handler
+
+(defmulti handler :event/type)
+
+(defmethod handler ::more-buttons
+  [{:keys [fx/context id] :as m}]
+  {:context (fx/swap-context context update ::ids (fnil conj []) (gensym :id))})
+
+(defmethod handler ::less-buttons
+  [{:keys [fx/context] :as m}]
+  {:context (-> context
+                (fx/swap-context update ::ids
+                                 #(or (when (seq %) (pop %)) []))
+                ; clean up state
+                (fx/swap-context update ::clicked
+                                 dissoc (peek (fx/sub context ::ids))))})
+
+(defmethod handler ::clicked
+  [{:keys [fx/context id] :as m}]
+  {:context (fx/swap-context context update-in [::clicked id] (fnil inc 0))})
+
+;; Views
+
+(defn buttons [{:keys [fx/context]}]
+  (let [clicked (fx/sub context ::clicked)]
+    {:fx/type :scroll-pane
+     :fit-to-width true
+     :fit-to-height true
+     :content
+     {:fx/type :h-box
+      :children (mapv (fn [id]
+                        {:fx/type :button
+                         :text (str "x" (get clicked id 0))
+                         :on-action {:event/type ::clicked
+                                     :id id}})
+                      (fx/sub context ::ids))}}))
+
+(defn sum-buttons [context]
+  (reduce #(let [clicked (fx/sub context ::clicked)]
+             (+ %1 (get clicked %2 0)))
+          0
+          (fx/sub context ::ids)))
+
+(defn view [{:keys [fx/context] :as m}]
+  {:fx/type :stage
+   :showing true
+   :always-on-top true
+   :width 600
+   :height 500
+   :scene {:fx/type :scene
+           :root {:fx/type :v-box
+                  :children
+                  [{:fx/type :h-box
+                    :children [{:fx/type :button
+                                :on-action {:event/type ::less-buttons}
+                                :text (str "Less buttons")}
+                               {:fx/type :button
+                                :on-action {:event/type ::more-buttons}
+                                :text (str "More buttons")}]}
+                   {:fx/type :label
+                    :text (str "Sum: " (fx/sub context sum-buttons))}
+                   {:fx/type buttons}]}}})
+
+;; Main app
+
+(declare *context app)
+
+(when (and (.hasRoot #'*context)
+           (.hasRoot #'app))
+  (fx/unmount-renderer *context (:renderer app)))
+
+(def *context
+  (atom (fx/create-context {})))
+
+(def app
+  (fx/create-app *context
+    :event-handler handler
+    :desc-fn (fn [_]
+               {:fx/type view})))

--- a/test/cljfx/context_test/context_sub_sometimes.clj
+++ b/test/cljfx/context_test/context_sub_sometimes.clj
@@ -1,0 +1,57 @@
+(ns cljfx.context-test.context-sub-sometimes
+  (:require [cljfx.api :as fx]))
+
+;; Event handler
+
+(defmulti handler :event/type)
+
+(defmethod handler ::clicked
+  [{:keys [fx/context id] :as m}]
+  {:context (-> context
+                (fx/swap-context update ::clicked (fnil inc 0))
+                (fx/swap-context update ::clicked-neg (fnil dec 0)))})
+
+(defmethod handler ::reset
+  [{:keys [fx/context id] :as m}]
+  {:context (fx/swap-context context assoc ::clicked 0 ::clicked-neg 0)})
+
+;; Views
+
+(defn button-text [context]
+  (let [clicked (or (fx/sub context ::clicked) 0)]
+    (if (< 2 clicked)
+      [clicked (fx/sub context ::clicked-neg)]
+      clicked)))
+
+(defn view [{:keys [fx/context] :as m}]
+  {:fx/type :stage
+   :showing true
+   :always-on-top true
+   :width 600
+   :height 500
+   :scene {:fx/type :scene
+           :root {:fx/type :v-box
+                  :children
+                  [{:fx/type :button
+                    :text (str "Reset")
+                    :on-action {:event/type ::reset}}
+                   {:fx/type :button
+                    :text (str "Clicked: " (fx/sub context button-text))
+                    :on-action {:event/type ::clicked}}]}}})
+
+;; Main app
+
+(declare *context app)
+
+(when (and (.hasRoot #'*context)
+           (.hasRoot #'app))
+  (fx/unmount-renderer *context (:renderer app)))
+
+(def *context
+  (atom (fx/create-context {})))
+
+(def app
+  (fx/create-app *context
+    :event-handler handler
+    :desc-fn (fn [_]
+               {:fx/type view})))

--- a/test/cljfx/context_test/empty_context.clj
+++ b/test/cljfx/context_test/empty_context.clj
@@ -1,0 +1,72 @@
+(ns cljfx.context-test.empty-context
+  (:require [cljfx.api :as fx]))
+
+; minimal example of bug in context where adding
+; a new entry to the root of the context does not
+; trigger rerenderings.
+
+; To reproduce:
+; 1. Run this file.
+; 2. Click the "Clicked x0" button a few times, it works.
+; 3. Click the "Reset via assoc" button, again Step 2 works fine.
+; 4. Click the "Reset via dissoc" button. Now, Step 2 skips "Clicked x1",
+;    and "Clicked x0" is shown twice!
+
+;; Initial State
+
+(defn init-state [] {::clicked nil})
+
+;; Views
+
+(defn view [{:keys [fx/context]}]
+  {:fx/type :stage
+   :showing true
+   :always-on-top true
+   :width 600
+   :height 500
+   :scene {:fx/type :scene
+           :root {:fx/type :v-box
+                  :children [{:fx/type :h-box
+                              :children [{:fx/type :button
+                                          :on-action {:event/type ::reset-assoc}
+                                          :text (str "Reset via assoc")}
+                                         {:fx/type :button
+                                          :on-action {:event/type ::reset-dissoc}
+                                          :text (str "Reset via dissoc")}]}
+                             (let [clicked (fx/sub context ::clicked)]
+                               {:fx/type :button
+                                :on-action {:event/type ::clicked
+                                            :clicked clicked}
+                                :text (str "Clicked x" (or clicked 0))}) ]}}})
+
+; Handlers
+
+(defmulti handler :event/type)
+(defmethod handler ::clicked
+  [{:keys [fx/context clicked]}]
+  {:context (fx/swap-context context update ::clicked (fnil inc 0))})
+
+(defmethod handler ::reset-dissoc
+  [{:keys [fx/context]}]
+  {:context (fx/swap-context context dissoc ::clicked)})
+
+(defmethod handler ::reset-assoc
+  [{:keys [fx/context]}]
+  {:context (fx/swap-context context assoc ::clicked nil)})
+
+;; Main app
+
+(declare *context app)
+
+(when (and (.hasRoot #'*context)
+           (.hasRoot #'app))
+  (fx/unmount-renderer *context (:renderer app)))
+
+(def *context
+  (atom (fx/create-context (init-state))))
+
+(def app
+  (fx/create-app *context
+    :event-handler handler
+    :desc-fn (fn [_]
+               {:fx/type view})))


### PR DESCRIPTION
Note: This pull request depends on https://github.com/cljfx/cljfx/pull/35, which changes `cljfx.context/invalidate-cache`.

# Problem

Direct dependencies of subscribed functions are not always synchronized with parent.

In particular, if both
1. A dependency's key-deps changed and
2. the dependency's return value remains the same

then the parent does not inherit changed key-deps.

This is demonstrated in `test/cljfx/context_test/context_dirty_entry_updates_key_deps.clj` in this pull request.

Here's how it _should_ work:

![dirty-key-path-fixed](https://user-images.githubusercontent.com/287396/62071834-61667600-b20b-11e9-9b5a-5449ff003748.gif)

However, it's broken in several ways, some fixed by https://github.com/cljfx/cljfx/pull/35.

With https://github.com/cljfx/cljfx/pull/35, the sum is not updated until a new button is added 

![context-dirty-with-35](https://user-images.githubusercontent.com/287396/62074435-cffa0280-b210-11e9-8085-06659e76f728.gif)

This is because the `view`'s cache entry is only updated when a new button is added, since it only depends on `#{::ids}`. This is the bug: it _should_ depend on `#{::ids ::clicked}`.

The `sum-buttons` function first depends on `#{::ids}`, then when a button is added, `sum-buttons` now depends on `#{::ids ::clicked}`. However, since the sum is still `0`, `view` does not evict its context cache entry (due to the logic in `sub-from-dirty`, and thus only depends on `#{::ids}`.

Here is the same app, but without the commits in https://github.com/cljfx/cljfx/pull/35

![dirty-key-path-broken](https://user-images.githubusercontent.com/287396/62071826-5dd2ef00-b20b-11e9-8c8a-8e90c52ef69f.gif)

Many clicks are lost and sum is not also not updated.

# Solution

The solution is to update the cache entry of the parent with the new key dependencies (if any) in the case where a dirty cache entry can be converted into a clean one.

A private helper function `cljfx.context/register-cache-entry` is factored out to share logic between `sub` and `sub-from-dirty`.

A minimal test is included: `cljfx.context-test/dirty-cache-entry-always-updates-its-key-deps`.

A minor enhancement included in this PR is that the `sub`s on dependencies in `sub-from-dirty` are added to the cache. I added a unit test to ensure this:

```clojure
        _ (facts
            "[parent-child] recalculated exactly once to verify that [template] cache entry should be evicted"
            @*parent-child-counter => 3)
```

Without this, `@*parent-child-counter` becomes 4, because the "miss" case of `sub-from-dirty` recalculates dependencies even though `sub-from-dirty` just recalculated them.

To avoid infinite loops between `sub-from-dirty` and `register-cache-entry`, `*processing-dirty*` is the currently processed dirty cache entries.

In the process of trying to test for infinite loops, I came across https://github.com/cljfx/cljfx/issues/36. There is no unit test for infinite loops pending that discussion, but I presume a similar error will be triggered.
